### PR TITLE
Add a flag to control which files are checked by liquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ for each executable or library:
 
 ### `x-liquidhaskell-options`
 Extra command line flags to pass to LiquidHaskell (these are described in the [LiquidHaskell
-README](https://github.com/ucsd-progsys/liquidhaskell)).
+README](https://github.com/ucsd-progsys/liquidhaskell#command-line-options)).
 ```
 library
   (... other fields ...)

--- a/README.md
+++ b/README.md
@@ -135,11 +135,12 @@ cabal configure -fliquidhaskell && cabal build
 
 ## Custom LiquidHaskell Flags
 
-Each library and executable in your package can specify its own extra command
-line flags to pass to LiquidHaskell (these are described in the [LiquidHaskell
-README](https://github.com/ucsd-progsys/liquidhaskell)). Simply add an
-`x-liquidhaskell-options` field to the relevant components:
+There are additional custom flag fields that you can add to your `.cabal` file
+for each executable or library:
 
+### `x-liquidhaskell-options`
+Extra command line flags to pass to LiquidHaskell (these are described in the [LiquidHaskell
+README](https://github.com/ucsd-progsys/liquidhaskell)).
 ```
 library
   (... other fields ...)
@@ -148,6 +149,22 @@ library
 executable myexecutable
   (... other fields ...)
   x-liquidhaskell-options: --diff
+```
+
+### `x-liquidhaskell-checked-files`
+Whitelist of files to check. This is convenient when you don't want to
+check your entire project at once.
+
+The list also supports directories, e.g. listing `A/B` will also include `A/B/C.hs`.
+When this field is missing `liquidhaskell-cabal` defaults to checking everything.
+```
+library
+  (... other fields ...)
+  x-liquidhaskell-checked-files: src/A.hs src/B
+
+executable myexecutable
+  (... other fields ...)
+  x-liquidhaskell-checked-files: app/Main.hs
 ```
 
 ## Custom `Setup.hs` Files

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ cabal configure -fliquidhaskell && cabal build
 
 (Running `cabal configure` without `-fliquidhaskell` will turn it back off.)
 
-## Custom LiquidHaskell Flags
+## Custom `liquidhaskell-cabal` options
 
-There are additional custom flag fields that you can add to your `.cabal` file
+There are additional custom option fields that you can add to your `.cabal` file
 for each executable or library:
 
 ### `x-liquidhaskell-options`

--- a/liquidhaskell-cabal.cabal
+++ b/liquidhaskell-cabal.cabal
@@ -24,6 +24,7 @@ library
   build-depends:       base >= 4.4 && < 5
                      , Cabal
                      , filepath >= 1.3 && <1.5
+                     , directory
   default-language:    Haskell2010
 
 source-repository head

--- a/liquidhaskell-cabal.cabal
+++ b/liquidhaskell-cabal.cabal
@@ -1,5 +1,5 @@
 name:                  liquidhaskell-cabal
-version:               0.2.0.0
+version:               0.2.1.0
 synopsis:              Liquid Haskell integration for Cabal and Stack
 description:           Provides support for checking projects using Cabal
                        and/or stack with LiquidHaskell.

--- a/src/LiquidHaskell/Cabal.hs
+++ b/src/LiquidHaskell/Cabal.hs
@@ -127,19 +127,26 @@ liquidHaskellHook args verbosityFlag pkg lbi = do
     withAllComponentsInBuildOrder pkg lbi $ \component clbi ->
       case component of
         CLib lib -> do
-          srcs <- findLibSources lib
-          verifyComponent verbosity lbi clbi (libBuildInfo lib)
+          let buildInfo' = libBuildInfo lib
+
+          srcs <- filterCheckedFiles (getCheckedFiles buildInfo') <$> findLibSources lib
+          verifyComponent verbosity lbi clbi buildInfo'
             "library" srcs
 
         CExe exe -> do
-          srcs <- findExeSources exe
-          verifyComponent verbosity lbi clbi (buildInfo exe)
+          let buildInfo' = buildInfo exe
+
+          srcs <- filterCheckedFiles (getCheckedFiles buildInfo') <$> findExeSources exe
+          verifyComponent verbosity lbi clbi buildInfo'
             ("executable " ++  unUnqualComponentName (exeName exe)) srcs
         _ -> return ()
 
 
 liquidHaskellOptions :: String
 liquidHaskellOptions = "x-liquidhaskell-options"
+
+liquidHaskellCheckedFiles :: String
+liquidHaskellCheckedFiles = "x-liquidhaskell-checked-files"
 
 --------------------------------------------------------------------------------
 -- Build Process Tweaks --------------------------------------------------------
@@ -183,6 +190,27 @@ getUserArgs desc bi =
         Right args -> return args
         Left err   -> dieNoVerbosity $
           "failed to parse LiquidHaskell options for " ++ desc ++ ": " ++ err
+
+--------------------------------------------------------------------------------
+-- Filter out files for which to run LiquidHaskell -----------------------------
+--------------------------------------------------------------------------------
+
+data CheckedFiles =
+    All
+  | Whitelist [FilePath]
+
+filterCheckedFiles :: CheckedFiles -> [FilePath] -> [FilePath]
+filterCheckedFiles All                 fps = fps
+filterCheckedFiles (Whitelist allowed) fps = allowed `intersect` fps
+
+getCheckedFiles :: BuildInfo -> CheckedFiles
+getCheckedFiles bi =
+  maybe All (Whitelist . splitOn ' ') $ lookup liquidHaskellCheckedFiles (customFieldsBI bi)
+  where
+    splitOn :: Char -> String -> [String]
+    splitOn _ []  = []
+    splitOn c str = let (pref, suff) = break (== c) str
+                     in pref : splitOn c (drop 1 suff)
 
 --------------------------------------------------------------------------------
 -- Construct GHC Options -------------------------------------------------------

--- a/src/LiquidHaskell/Cabal.hs
+++ b/src/LiquidHaskell/Cabal.hs
@@ -132,7 +132,7 @@ liquidHaskellHook args verbosityFlag pkg lbi = do
           let buildInfo' = libBuildInfo lib
               checkedFiles = getCheckedFiles buildInfo'
 
-          warnMissingCheckedFiles checkedFiles
+          verifyCheckedFiles checkedFiles
 
           srcs <- filterCheckedFiles checkedFiles <$> findLibSources lib
           verifyComponent verbosity lbi clbi buildInfo'
@@ -142,7 +142,7 @@ liquidHaskellHook args verbosityFlag pkg lbi = do
           let buildInfo' = buildInfo exe
               checkedFiles = getCheckedFiles buildInfo'
 
-          warnMissingCheckedFiles checkedFiles
+          verifyCheckedFiles checkedFiles
 
           srcs <- filterCheckedFiles checkedFiles <$> findExeSources exe
           verifyComponent verbosity lbi clbi buildInfo'
@@ -222,11 +222,11 @@ getCheckedFiles bi =
     splitOn c str = let (pref, suff) = break (== c) str
                      in pref : splitOn c (drop 1 suff)
 
-warnMissingCheckedFiles :: CheckedFiles -> IO ()
-warnMissingCheckedFiles All = pure ()
-warnMissingCheckedFiles (Whitelist allowed) = for_ allowed $ \file -> do
+verifyCheckedFiles :: CheckedFiles -> IO ()
+verifyCheckedFiles All = pure ()
+verifyCheckedFiles (Whitelist allowed) = for_ allowed $ \file -> do
   exists <- doesPathExist file
-  unless exists $ putStrLn $ "Warning: " ++ file ++ " specified in " ++ liquidHaskellCheckedFiles ++ " is missing!"
+  unless exists $ dieNoVerbosity $ file ++ " specified in " ++ liquidHaskellCheckedFiles ++ " is missing!"
 
 --------------------------------------------------------------------------------
 -- Construct GHC Options -------------------------------------------------------

--- a/src/LiquidHaskell/Cabal.hs
+++ b/src/LiquidHaskell/Cabal.hs
@@ -209,7 +209,9 @@ data CheckedFiles =
 
 filterCheckedFiles :: CheckedFiles -> [FilePath] -> [FilePath]
 filterCheckedFiles All                 fps = fps
-filterCheckedFiles (Whitelist allowed) fps = allowed `intersect` fps
+filterCheckedFiles (Whitelist allowed) fps = intersectBy prefixOrEqual fps allowed
+  where
+    prefixOrEqual x y = x == y || y `isPrefixOf` x
 
 getCheckedFiles :: BuildInfo -> CheckedFiles
 getCheckedFiles bi =


### PR DESCRIPTION
Added a flag - `x-liquidhaskell-checked-files` which allows a user to specify a whitelist of files for which `liquid` should run. This is so that he can more easily verify only a bit of his project at once.
